### PR TITLE
Don't throw an error when no migrations directory exists

### DIFF
--- a/__tests__/migrate.test.js
+++ b/__tests__/migrate.test.js
@@ -101,7 +101,7 @@ describe('bin/db', () => {
 		});
 
 		it("doesn't run when no pending migrations exist", () => {
-			const result = execSync('bin/db run');
+			const result = execSync('bin/db run-migrations');
 
 			expect(result).toContain('No pending migrations to run.');
 			expect(result).not.toContain('Running migrations:');
@@ -114,7 +114,7 @@ describe('bin/db', () => {
 				}
 			});
 
-			expect(() => execSync('bin/db run')).toThrowError();
+			expect(() => execSync('bin/db run-migrations')).toThrowError();
 			await expect(Migration.countDocuments()).resolves.toBe(0);
 		});
 	});

--- a/bin/db-run-migrations
+++ b/bin/db-run-migrations
@@ -40,6 +40,7 @@ const runMigration = async migrationName => {
 }
 
 const fetchPendingMigrations = (migrationNames) => {
+  if (!fs.existsSync(serverMigrationPath())) return []
   const migrationFileNames = fs.readdirSync(serverMigrationPath())
   return _.reject(migrationFileNames, name => _.includes(migrationNames, name))
 }


### PR DESCRIPTION
- **Fixes a bug causing an error to be thrown when the migrations directory doesn't exist.**