### PR TITLE
Don't throw an error when no migrations dir

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const mkdirp = require('mkdirp');
 const Migration = require('./migration.model');
 
 const config = require(`${process.cwd()}/package.json`).db || {};
@@ -11,7 +12,7 @@ const serverMigrationPath = () =>
 
 const createMigrationsDirectory = () => {
 	if (!fs.existsSync(serverMigrationPath())) {
-		fs.mkdirSync(serverMigrationPath());
+		mkdirp.sync(serverMigrationPath());
 	}
 };
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "commander": "^2.18.0",
     "jsonfile": "^5.0.0",
     "lodash": "^4.17.11",
+    "mkdirp": "^0.5.1",
     "moment": "^2.22.2",
     "mongoose": "^5.3.0",
     "prettier": "^1.14.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3959,7 +3959,7 @@ mixin-deep@^1.2.0:
 
 mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
-  resolved "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"


### PR DESCRIPTION
- **Fixes an error that was being thrown due to a non-existent migrations directory.**